### PR TITLE
Update check_before_use.sh

### DIFF
--- a/scripts/check_before_use.sh
+++ b/scripts/check_before_use.sh
@@ -30,7 +30,7 @@ else
 MAJORVER="1"
 MINRELEASE="0"
 MINVERSION="0"
-_RELEASE=`sudo -u root -S /usr/bin/vtlcmd -V| awk '{print $2}'|cut -d "-" -f1`
+_RELEASE=`sudo -u root -S /usr/bin/vtlcmd -V 2>&1| awk '{print $2}'|cut -d "-" -f1`
 MAJ=`echo $_RELEASE|awk -F. '{print $1}'`
 RELEASE=`echo $_RELEASE|awk -F. '{print $2}'`
 VERSION=`echo $_RELEASE|awk -F. '{print $3}'`


### PR DESCRIPTION
Whoops! I filed an MR with Mark before reading that you're taking the lead on this project.

Later versions of mhvtl -V output to stderr, which causes the check_before_use script not to catch the version correctly. This is a quick hack to fix that.